### PR TITLE
DOM-6363 Change notebook_dir to '/' and default_url to '/(lab|tree)/mnt'

### DIFF
--- a/Jupyterlab/start.sh
+++ b/Jupyterlab/start.sh
@@ -9,12 +9,12 @@ PREFIX=/${DOMINO_PROJECT_OWNER}/${DOMINO_PROJECT_NAME}/notebookSession/${DOMINO_
 
 cat >> $CONF_FILE << EOF
 c = get_config()
-c.NotebookApp.notebook_dir = '${DRT_WORKING_DIR:-"/mnt"}'
+c.NotebookApp.notebook_dir = '${DRT_WORKING_DIR:-"/"}'
 c.NotebookApp.base_url = '${PREFIX}'
 c.NotebookApp.base_kernel_url = '${PREFIX}'
 c.NotebookApp.base_project_url = '${PREFIX}'
 c.NotebookApp.tornado_settings = {'headers': {'Content-Security-Policy': 'frame-ancestors *'}, 'static_url_prefix': '${PREFIX}static/'}
-c.NotebookApp.default_url = '/lab'
+c.NotebookApp.default_url = '/lab/mnt'
 c.NotebookApp.token = u''
 EOF
                                                                                                                                     

--- a/Jupyterlab/start.sh
+++ b/Jupyterlab/start.sh
@@ -14,7 +14,7 @@ c.NotebookApp.base_url = '${PREFIX}'
 c.NotebookApp.base_kernel_url = '${PREFIX}'
 c.NotebookApp.base_project_url = '${PREFIX}'
 c.NotebookApp.tornado_settings = {'headers': {'Content-Security-Policy': 'frame-ancestors *'}, 'static_url_prefix': '${PREFIX}static/'}
-c.NotebookApp.default_url = '/lab/mnt'
+c.NotebookApp.default_url = '/lab/tree/mnt'
 c.NotebookApp.token = u''
 EOF
                                                                                                                                     

--- a/jupyter-tensorboard/start
+++ b/jupyter-tensorboard/start
@@ -4,15 +4,14 @@ set -o nounset -o errexit -o pipefail
 IP_ADDR=$(/sbin/ifconfig eth0 | grep "inet addr" | cut -d ":" -f2 | cut -d " " -f1)
 CONF_DIR="$HOME/.ipython/profile_default"
 CONF_FILE="${CONF_DIR}/ipython_notebook_config.py"
-MAIN_PROJECT_REDIRECT_DIR=${DOMINO_WORKING_DIR#"/mnt"}
 
 mkdir -p "${CONF_DIR}"
 
 cat <<EOF >>"${CONF_FILE}"
 c = get_config()
-c.NotebookApp.notebook_dir = '${DRT_WORKING_DIR:-"/mnt"}'
+c.NotebookApp.notebook_dir = '${DRT_WORKING_DIR:-"/"}'
 c.NotebookApp.tornado_settings = {'headers': {'Content-Security-Policy': 'frame-ancestors *'}}
-c.NotebookApp.default_url = '/tree${MAIN_PROJECT_REDIRECT_DIR}'
+c.NotebookApp.default_url = '/tree${DOMINO_WORKING_DIR}'
 EOF
 
 # Replace * in "--ip=*" with the actual IP address of the container

--- a/jupyter/start
+++ b/jupyter/start
@@ -4,15 +4,14 @@ set -o nounset -o errexit -o pipefail
 IP_ADDR=$(/sbin/ifconfig eth0 | grep "inet addr" | cut -d ":" -f2 | cut -d " " -f1)
 CONF_DIR="$HOME/.ipython/profile_default"
 CONF_FILE="${CONF_DIR}/ipython_notebook_config.py"
-MAIN_PROJECT_REDIRECT_DIR=${DOMINO_WORKING_DIR#"/mnt"}
 
 mkdir -p "${CONF_DIR}"
 
 cat <<EOF >>"${CONF_FILE}"
 c = get_config()
-c.NotebookApp.notebook_dir = '${DRT_WORKING_DIR:-"/mnt"}'
+c.NotebookApp.notebook_dir = '${DRT_WORKING_DIR:-"/"}'
 c.NotebookApp.tornado_settings = {'headers': {'Content-Security-Policy': 'frame-ancestors *'}}
-c.NotebookApp.default_url = '/tree${MAIN_PROJECT_REDIRECT_DIR}'
+c.NotebookApp.default_url = '/tree${DOMINO_WORKING_DIR}'
 EOF
 
 # Replace * in "--ip=*" with the actual IP address of the container


### PR DESCRIPTION
The purpose: enable users to navigate to /repos within their IPython/Jupyter classic/JupyterLab interface. We achieve that by changing c.NotebookApp.notebook_dir and c.NotebookApp.default_url values in ipython_notebook_config.py file created in the start scripts.

**Testing**: confirmed that this change does not break relative path references in interactive notebooks.