### PR TITLE
pinning Jupyterlab version

### DIFF
--- a/Jupyterlab/install
+++ b/Jupyterlab/install
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -o nounset -o errexit -o pipefail
 
-pip install --upgrade six && pip install --upgrade jupyterlab && pip install --upgrade jupyter
+pip install --upgrade six && pip install jupyterlab==0.31.12 && pip install --upgrade jupyter

--- a/Jupyterlab/start.sh
+++ b/Jupyterlab/start.sh
@@ -14,9 +14,9 @@ c.NotebookApp.base_url = '${PREFIX}'
 c.NotebookApp.base_kernel_url = '${PREFIX}'
 c.NotebookApp.base_project_url = '${PREFIX}'
 c.NotebookApp.tornado_settings = {'headers': {'Content-Security-Policy': 'frame-ancestors *'}, 'static_url_prefix': '${PREFIX}static/'}
-c.NotebookApp.default_url = '/lab/tree/mnt'
+c.NotebookApp.default_url = '/lab/tree${DOMINO_WORKING_DIR}'
 c.NotebookApp.token = u''
 EOF
-                                                                                                                                    
+
 COMMAND='jupyter-lab --config="$CONF_FILE" --no-browser --ip="0.0.0.0" 2>&1'
-eval ${COMMAND}                                                                                                               
+eval ${COMMAND} 


### PR DESCRIPTION
Pinning Jupyterlab to version 0.31.12
Setting c.NotebookApp.default_url = '/lab/tree${DOMINO_WORKING_DIR}' so Jupyterlab always opens in the working directory