### PR TITLE
Update URL for Zeppelin

### DIFF
--- a/Zeppelin/install
+++ b/Zeppelin/install
@@ -1,4 +1,4 @@
- wget http://mirror.reverse.net/pub/apache/zeppelin/zeppelin-0.7.3/zeppelin-0.7.3-bin-all.tgz && \
+ wget http://archive.apache.org/dist/zeppelin/zeppelin-0.7.3/zeppelin-0.7.3-bin-all.tgz && \
  tar xvzf zeppelin-0.7.3-bin-all.tgz 
  rm -rf /opt/zeppelin 
  mv zeppelin-0.7.3-bin-all /opt/zeppelin 


### PR DESCRIPTION
Zeppelin is now on 0.8.0. The original mirror no longer exists. I updated it with an archive link for 0.7.3.