### PR TITLE
Upgrade the JupyterLab version to 1.2.12

### DIFF
--- a/Jupyterlab/install
+++ b/Jupyterlab/install
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -o nounset -o errexit -o pipefail
 
- pip install jupyterlab==1.2.5
+ pip install jupyterlab==1.2.12


### PR DESCRIPTION
This updates our JupyterLab installation to 1.2.12.  This is necessary to enable JupyterLab in Safari; it includes a workaround for a Safari bug that breaks local storage access.