### PR TITLE
Update start script to account for a default python interpreter version

### DIFF
--- a/vscode/start
+++ b/vscode/start
@@ -1,11 +1,12 @@
 #!/bin/bash
 
 FILE=${DOMINO_WORKING_DIR}/vscode-settings/User/settings.json
+VSCODEFILE=${DOMINO_WORKING_DIR}/.vscode/settings.json
 
 ##turn off auto updating a VSCode extensions
 #update a user setting file if it does exist
 if [ -f "$FILE" ]; then
-jq --argjson value false '. + {"extensions.autoUpdate": $value}' $FILE > temp-settings.json
+jq --argjson value false --arg PYTHONINTERPRETERPATH "$(which python)" '. + {"extensions.autoUpdate": $value,"python.pythonPath": $PYTHONINTERPRETERPATH}' $FILE > temp-settings.json
 mv temp-settings.json $FILE
 rm -rf temp-settings.json
 fi
@@ -13,7 +14,18 @@ fi
 #add a user setting file if it doesn't exist
 if [ ! -f "$FILE" ]; then
 mkdir -p ${DOMINO_WORKING_DIR}/vscode-settings/User/
-printf '{\n\t"extensions.autoUpdate":false\n}\n' > ${DOMINO_WORKING_DIR}/vscode-settings/User/settings.json
+printf "{\n\t\"extensions.autoUpdate\":false,\n\t\"python.pythonPath\": \"$(which python)\"\n}\n" > ${DOMINO_WORKING_DIR}/vscode-settings/User/settings.json
+fi
+
+if [ ! -f "$VSCODEFILE" ]; then
+mkdir -p ${DOMINO_WORKING_DIR}/.vscode
+printf "{\n\t\"extensions.autoUpdate\":false,\n\t\"python.pythonPath\": \"$(which python)\"\n}\n" > $VSCODEFILE
+fi
+
+if [ -f "$VSCODEFILE" ]; then
+jq --argjson value false --arg PYTHONINTERPRETERPATH "$(which python)" '. + {"extensions.autoUpdate": $value,"python.pythonPath": $PYTHONINTERPRETERPATH}' $VSCODEFILE > temp-settings.json
+mv temp-settings.json $VSCODEFILE
+rm -rf temp-settings.json
 fi
 
 code-server ${DOMINO_WORKING_DIR} --user-data-dir ${DOMINO_WORKING_DIR}/vscode-settings --auth none --bind-addr 0.0.0.0:8888 --extensions-dir ${HOME}/.local/share/code-server/extensions --disable-telemetry


### PR DESCRIPTION
The python interpreter in VS Code was defaulting to 2.7.  These changes set it to $(which python) which also allows for that to be changed once the workspace is started up.  Needed to make the changes to .vscode/settings.josn as well as user settings.json.