### PR TITLE
(4.5.0) Removed piping output to files for jupyter/jupyterlab

### DIFF
--- a/Jupyterlab/start.sh
+++ b/Jupyterlab/start.sh
@@ -16,5 +16,5 @@ c.NotebookApp.default_url = '/lab/tree${DOMINO_WORKING_DIR}'
 c.NotebookApp.token = u''
 EOF
 
-COMMAND='jupyter-lab --config="$CONF_FILE" --no-browser --ip="0.0.0.0" 2>&1'
+COMMAND='jupyter-lab --config="$CONF_FILE" --no-browser --ip="0.0.0.0"'
 eval ${COMMAND} 

--- a/jupyter/start
+++ b/jupyter/start
@@ -20,7 +20,7 @@ c.NotebookApp.disable_check_xsrf = True
 EOF
 
 # Replace * in "--ip=*" with the actual IP address of the container
-COMMAND='jupyter notebook --no-browser --ip=0.0.0.0 2>&1'
+COMMAND='jupyter notebook --no-browser --ip=0.0.0.0'
 FINAL_COMMAND=$(echo "${COMMAND}" | sed "s/--ip=\\*/--ip=${IP_ADDR}/")
 
 eval ${FINAL_COMMAND}


### PR DESCRIPTION
We pipe the output for Jupyter and JupyterLab notebooks to `stdout.txt`, which means that if two users in a project both have workspaces open at the same time they are guaranteed to have a merge conflict because their `stdout.txt` files will be different. 

From my discussions we don't know why we initially made the decision to pipe to `stdout.txt`, and this is not something we do for other notebooks.

Jira: https://dominodatalab.atlassian.net/browse/DOM-27965