### PR TITLE
(4.5.) Unpin jupyterlab version now that git extension works on later versions

### DIFF
--- a/Jupyterlab/install
+++ b/Jupyterlab/install
@@ -1,4 +1,3 @@
 #!/bin/bash
 set -o nounset -o errexit -o pipefail
-pip install 'jupyterlab<3.0.0'
-# jupyterlab git extentions are not compatible withe jupyterlab > 3.0.0 as of this writing, 1/13/2021
+pip install jupyterlab


### PR DESCRIPTION
In the past we forced `JupyterLab` to be a version < 3.0.0 because git extensions for it didn't work for that version. However, this has since changed and now git extensions only work for 3.0.0+.

https://github.com/jupyterlab/jupyterlab-git