### PR TITLE
change rstudio link

### DIFF
--- a/rstudio/install
+++ b/rstudio/install
@@ -4,7 +4,7 @@ set -o nounset -o errexit -o pipefail
 mkdir -p /tmp/rstudio-temp
 cd /tmp/rstudio-temp
 apt-get update -y && apt-get install -y gdebi libapparmor1
-wget  -q https://download2.rstudio.org/server/trusty/amd64/rstudio-server-1.4.1707-amd64.deb
+wget  -q https://s3.amazonaws.com/rstudio-ide-build/server/bionic/amd64/rstudio-server-1.4.1707-amd64.deb
 gdebi -n rstudio-server-1.4.1707-amd64.deb
 ln -sf /usr/lib/rstudio-server /usr/local/lib/rstudio-server 
 chown -R root:root /usr/lib/rstudio-server
@@ -19,5 +19,6 @@ chown ubuntu:ubuntu /etc/rstudio/rserver.conf
 #Make rmarkdown::render work outside of rstudio. https://github.com/rstudio/rmarkdown/blob/master/PANDOC.md
 ln -sf /usr/lib/rstudio-server/bin/pandoc/pandoc /usr/local/bin
 ln -sf /usr/lib/rstudio-server/bin/pandoc/pandoc-citeproc /usr/local/bin
+
 
 rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Bumping version to 1.4 for domino 4.5 release

See https://dominodatalab.atlassian.net/browse/DOM-28206 for more details on chown changes
This is tracked by ticket here: https://dominodatalab.atlassian.net/browse/DOM-28113