### PR TITLE
Revert jupyterlab start to /

### DIFF
--- a/Jupyterlab/start.sh
+++ b/Jupyterlab/start.sh
@@ -9,6 +9,7 @@ PREFIX=/${DOMINO_PROJECT_OWNER}/${DOMINO_PROJECT_NAME}/notebookSession/${DOMINO_
 
 cat >> $CONF_FILE << EOF
 c = get_config()
+c.NotebookApp.notebook_dir = '/'
 c.NotebookApp.base_url = '${PREFIX}'
 c.NotebookApp.tornado_settings = {'headers': {'Content-Security-Policy': 'frame-ancestors *'}, 'static_url_prefix': '${PREFIX}static/'}
 c.NotebookApp.default_url = '/lab/tree${DOMINO_WORKING_DIR}'

--- a/Jupyterlab/start.sh
+++ b/Jupyterlab/start.sh
@@ -9,7 +9,6 @@ PREFIX=/${DOMINO_PROJECT_OWNER}/${DOMINO_PROJECT_NAME}/notebookSession/${DOMINO_
 
 cat >> $CONF_FILE << EOF
 c = get_config()
-c.NotebookApp.notebook_dir = '${DOMINO_WORKING_DIR}'
 c.NotebookApp.base_url = '${PREFIX}'
 c.NotebookApp.tornado_settings = {'headers': {'Content-Security-Policy': 'frame-ancestors *'}, 'static_url_prefix': '${PREFIX}static/'}
 c.NotebookApp.default_url = '/lab/tree${DOMINO_WORKING_DIR}'


### PR DESCRIPTION
While moving the starting directory for jupyterlab to `DOMINO_WORKING_DIR` will cause it to open at the appropriate working dir, it prevents users from navigating to parent directories. This is a bigger issue than not starting in the correct directory in the first place.